### PR TITLE
Update startup_vector_table.c

### DIFF
--- a/startup_vector_table.c
+++ b/startup_vector_table.c
@@ -2,6 +2,7 @@
 #include "exception_handlers.h"
 #include "lm4f120h5qr.h"
 #include "unicorn.h"
+#include "bsp.h"
 
 //used to substitute instead of the IAR generic definition of the interrupt vector table
 
@@ -15,7 +16,7 @@ void handler_NMI(void) //denial of service for now
 
 void handler_HardFault(void) //denial of service for now
 {
-  while(1) {}
+  while(1) { NVIC_SystemReset(); }
 }
 
 void handler_MemoryManagementFault(void) //denial of service for now


### PR DESCRIPTION
startup_vector_table.c
    - added '#include "bsp.h"' to allow for setting GPIO pins in the Systick handler and Pendsv
    -  added "NVIC_SystemReset()" to the hardfault handler so when you crash the board it resets instead of denial of service (while(1))

no brainer changes really